### PR TITLE
Support dual stack for IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip3 install --no-cache-dir /httpbin
 
 EXPOSE 80
 
-CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]
+CMD ["gunicorn", "-b", "[::]:80", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
This allows ipv4 + ipv6 support

With this change:
```
$ curl '127.0.0.1:8081/get'
{"args":{},"headers":{"Accept":"*/*","Host":"127.0.0.1:8081","User-Agent":"curl/7.67.0"},"origin":"::ffff:127.0.0.1","url":"http://127.0.0.1:8081/get"}
$ curl '[::1]:8081/get'
{"args":{},"headers":{"Accept":"*/*","Host":"[::1]:8081","User-Agent":"curl/7.67.0"},"origin":"::1","url":"http://[::1]:8081/get"}
```